### PR TITLE
Fix CSS output for RGBColor

### DIFF
--- a/lib/Primal/Color/RGBColor.php
+++ b/lib/Primal/Color/RGBColor.php
@@ -100,7 +100,7 @@ class RGBColor extends Color {
 	}
 	
 	function toCSS($alpha = null) {
-		return (($alpha === true || $this->alpha < 1) && $alpha !== false) ? "hsla({$this->red}, {$this->green}, {$this->blue}, {$this->alpha})" : "hsl({$this->red}, {$this->green}, {$this->blue})";
+		return (($alpha === true || $this->alpha < 1) && $alpha !== false) ? "rgba({$this->red}, {$this->green}, {$this->blue}, {$this->alpha})" : "rgb({$this->red}, {$this->green}, {$this->blue})";
 	}
 	
 	function toHex() {


### PR DESCRIPTION
The `toCSS()` method of `RGBColor` incorrectly uses hsla/hsl with RGB components.

Also, HSVColor uses hsl as well, which is incorrect, so it might be better to convert it to another format and use its toCSS().
