### PR TITLE
Fix color spacing

### DIFF
--- a/lib/Primal/Color/HSLColor.php
+++ b/lib/Primal/Color/HSLColor.php
@@ -34,14 +34,14 @@ class HSLColor extends Color {
 		$a = $this->alpha;
 		
 		if ($s === 0) {
-			return new RGBColor($l * 256, $l * 256, $l * 256);
+			return new RGBColor($l * 255, $l * 255, $l * 255);
 		} else {
 			$q = ($l < 0.5) ? $l * (1 + $s) : $l + $s - $l * $s;
 			$p = 2 * $l - $q;
 			return new RGBColor(
-				static::HueToFactor($p, $q, $h + 1 / 3) * 256,
-				static::HueToFactor($p, $q, $h        ) * 256,
-				static::HueToFactor($p, $q, $h - 1 / 3) * 256
+				static::HueToFactor($p, $q, $h + 1 / 3) * 255,
+				static::HueToFactor($p, $q, $h        ) * 255,
+				static::HueToFactor($p, $q, $h - 1 / 3) * 255
 			);
 		}
 	}

--- a/lib/Primal/Color/HSVColor.php
+++ b/lib/Primal/Color/HSVColor.php
@@ -70,7 +70,7 @@ class HSVColor extends Color {
 			$b = $q;
 			break;
 		}
-		return new RGBColor($r * 256, $g * 256, $b * 256, $a);
+		return new RGBColor($r * 255, $g * 255, $b * 255, $a);
 	}
 	
 	function toCSS($alpha = null) {

--- a/lib/Primal/Color/RGBColor.php
+++ b/lib/Primal/Color/RGBColor.php
@@ -16,9 +16,9 @@ class RGBColor extends Color {
 	}
 	
 	function toHSV() {
-		$r = ((int)$this->red   % 256) / 256;
-		$g = ((int)$this->green % 256) / 256;
-		$b = ((int)$this->blue  % 256) / 256;
+		$r = ((int)$this->red   % 256) / 255;
+		$g = ((int)$this->green % 256) / 255;
+		$b = ((int)$this->blue  % 256) / 255;
 		$a = $this->alpha;
 		
 		$max = max($r, $g, $b);
@@ -47,9 +47,9 @@ class RGBColor extends Color {
 	}
 	
 	function toHSL() {
-		$r = ((int)$this->red   % 256) / 256;
-		$g = ((int)$this->green % 256) / 256;
-		$b = ((int)$this->blue  % 256) / 256;
+		$r = ((int)$this->red   % 256) / 255;
+		$g = ((int)$this->green % 256) / 255;
+		$b = ((int)$this->blue  % 256) / 255;
 		$a = $this->alpha;
 		
 		$max = max($r, $g, $b);
@@ -78,9 +78,9 @@ class RGBColor extends Color {
 	}
 	
 	function toCMYK() {
-		$r = ((int)$this->red   % 256) / 256;
-		$g = ((int)$this->green % 256) / 256;
-		$b = ((int)$this->blue  % 256) / 256;
+		$r = ((int)$this->red   % 256) / 255;
+		$g = ((int)$this->green % 256) / 255;
+		$b = ((int)$this->blue  % 256) / 255;
 		$a = $this->alpha;
 
 		if ($r === 0 && $g === 0 && $b===0) {


### PR DESCRIPTION
RGB values run from 0 to 255, so when converting to/from a 0..1 range, it should be divided/multiplied by 255, so that a true red value (255) becomes 1.

The `% 256` is still correct, however it might be better to do a `min(255, $variable)` instead, so that the color components don't wrap around.
