### PR TITLE
Move required PHP version to 5.3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.10"
+		"php": ">=5.3.3"
 	},
 	"type": "library",
 	"autoload": {


### PR DESCRIPTION
There does not appear to be a reason this is set to PHP 5.3.10

Moving to PHP 5.3.3 aligns with the default version in CentOS and falls
under other distributions. Ubuntu 12.04 LTS does provide 5.3.10.
