### PR TITLE
Changed array offsets to fetch correct subparts in GetNamedColor

### DIFF
--- a/lib/Primal/Color/Parser.php
+++ b/lib/Primal/Color/Parser.php
@@ -65,7 +65,7 @@ class Parser {
 		
 		$chunks = array();
 		if (preg_match(static::$patterns['hex6'], static::$named_colors[$input], $chunks)) {
-			return new RGBColor(hexdec($chunks[0]), hexdec($chunks[1]), hexdec($chunks[2]));
+			return new RGBColor(hexdec($chunks[1]), hexdec($chunks[2]), hexdec($chunks[3]));
 		}
 		
 		return false;


### PR DESCRIPTION
Changed array offsets to fetch correct subparts from preg_matched hex color in GetNamedColor. Array index 0 is the full captured match.
