### PR TITLE
Fix: comma in css floats

### DIFF
--- a/lib/Primal/Color/CMYKColor.php
+++ b/lib/Primal/Color/CMYKColor.php
@@ -60,7 +60,7 @@ class CMYKColor extends Color {
 	public function toCSS($alpha = null) {
 		return ($alpha === true || $this->alpha < 1) && $alpha !== false
 				? sprintf('device-cmyk(%d%%, %d%%, %d%%, %d%%, %s)',
-						$this->cyan, $this->magenta, $this->yellow, $this->black, $this->alpha)
+						$this->cyan, $this->magenta, $this->yellow, $this->black, str_replace(',', '.', $this->alpha))
 				: sprintf('device-cmyk(%d%%, %d%%, %d%%, %d%%)',
 						$this->cyan, $this->magenta, $this->yellow, $this->black);
 	}

--- a/lib/Primal/Color/CMYKColor.php
+++ b/lib/Primal/Color/CMYKColor.php
@@ -60,7 +60,7 @@ class CMYKColor extends Color {
 	public function toCSS($alpha = null) {
 		return ($alpha === true || $this->alpha < 1) && $alpha !== false
 				? sprintf('device-cmyk(%d%%, %d%%, %d%%, %d%%, %s)',
-						$this->cyan, $this->magenta, $this->yellow, $this->black, str_replace(',', '.', $this->alpha))
+						$this->cyan, $this->magenta, $this->yellow, $this->black, number_format($this->alpha, 2, '.', ''))
 				: sprintf('device-cmyk(%d%%, %d%%, %d%%, %d%%)',
 						$this->cyan, $this->magenta, $this->yellow, $this->black);
 	}

--- a/lib/Primal/Color/HSLColor.php
+++ b/lib/Primal/Color/HSLColor.php
@@ -72,7 +72,7 @@ class HSLColor extends Color {
 	 */
 	public function toCSS($alpha = null) {
 		return ($alpha === true || $this->alpha < 1) && $alpha !== false
-			? sprintf('hsla(%d, %d, %d, %s)', $this->hue, $this->saturation, $this->luminance, $this->alpha)
+			? sprintf('hsla(%d, %d, %d, %s)', $this->hue, $this->saturation, $this->luminance, str_replace(',', '.', $this->alpha))
 			: sprintf('hsl(%d, %d, %d)', $this->hue, $this->saturation, $this->luminance);
 	}
 }

--- a/lib/Primal/Color/HSLColor.php
+++ b/lib/Primal/Color/HSLColor.php
@@ -72,7 +72,7 @@ class HSLColor extends Color {
 	 */
 	public function toCSS($alpha = null) {
 		return ($alpha === true || $this->alpha < 1) && $alpha !== false
-			? sprintf('hsla(%d, %d, %d, %s)', $this->hue, $this->saturation, $this->luminance, str_replace(',', '.', $this->alpha))
+			? sprintf('hsla(%d, %d, %d, %s)', $this->hue, $this->saturation, $this->luminance, number_format($this->alpha, 2, '.', ''))
 			: sprintf('hsl(%d, %d, %d)', $this->hue, $this->saturation, $this->luminance);
 	}
 }

--- a/lib/Primal/Color/RGBColor.php
+++ b/lib/Primal/Color/RGBColor.php
@@ -116,7 +116,7 @@ class RGBColor extends Color {
 	 */
 	public function toCSS($alpha = null) {
 		return ($alpha === true || $this->alpha < 1) && $alpha !== false
-			? sprintf('rgba(%d, %d, %d, %s)', $this->red, $this->green, $this->blue, str_replace(',', '.', $this->alpha))
+			? sprintf('rgba(%d, %d, %d, %s)', $this->red, $this->green, $this->blue, number_format($this->alpha, 2, '.', ''))
 			: sprintf('rgb(%d, %d, %d)', $this->red, $this->green, $this->blue);
 	}
 

--- a/lib/Primal/Color/RGBColor.php
+++ b/lib/Primal/Color/RGBColor.php
@@ -116,7 +116,7 @@ class RGBColor extends Color {
 	 */
 	public function toCSS($alpha = null) {
 		return ($alpha === true || $this->alpha < 1) && $alpha !== false
-			? sprintf('rgba(%d, %d, %d, %s)', $this->red, $this->green, $this->blue, $this->alpha)
+			? sprintf('rgba(%d, %d, %d, %s)', $this->red, $this->green, $this->blue, str_replace(',', '.', $this->alpha))
 			: sprintf('rgb(%d, %d, %d)', $this->red, $this->green, $this->blue);
 	}
 


### PR DESCRIPTION
In some system localization settings float numbers are printed with comma. But only dot is acceptable in float values in CSS. So a code that changes comma to dot is added.