### PR TITLE
fixes incorrect parsing of hex3 colours

### DIFF
--- a/lib/Primal/Color/Parser.php
+++ b/lib/Primal/Color/Parser.php
@@ -81,7 +81,7 @@ class Parser {
 	function hsva () {$this->result = new HSVColor((int)$this->chunks[1], (int)$this->chunks[2], (int)$this->chunks[3], (float)$this->chunks[4]);}
 	function hsv  () {$this->result = new HSVColor((int)$this->chunks[1], (int)$this->chunks[2], (int)$this->chunks[3]);}
 	function hex6 () {$this->result = new RGBColor(hexdec($this->chunks[1]), hexdec($this->chunks[2]), hexdec($this->chunks[3]));}
-	function hex3 () {$this->result = new RGBColor(hexdec($this->chunks[1])*16, hexdec($this->chunks[2])*16, hexdec($this->chunks[3])*16);}
+	function hex3 () {$this->result = new RGBColor(hexdec($this->chunks[1].$this->chunks[1]), hexdec($this->chunks[2].$this->chunks[2]), hexdec($this->chunks[3].$this->chunks[3]));}
 
 	
 	static $patterns = array(


### PR DESCRIPTION
In your current master, parsing a hex3

```
echo \Primal\Color\Parser::Parse('#eee')->toCSS();
// rgb(224, 224, 224);
```

is incorrect as the correct result is `rgb(238, 238, 238)`.

This fixes the issue.