### PR TITLE
Fix PHP 8.2 deprecation warning

### DIFF
--- a/lib/Primal/Color/Parser.php
+++ b/lib/Primal/Color/Parser.php
@@ -6,6 +6,7 @@ class Parser {
 	
 	protected $chunks;
 	protected $result;
+	protected $type;
 
 
 	function __construct($input) {


### PR DESCRIPTION
In PHP 8.2 we have this deprecation warning:

```
Creation of dynamic property Primal\Color\Parser::$type is deprecated
```

Let's fix it.